### PR TITLE
fix proxy url

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -314,7 +314,7 @@ def _add_proxy(session, config):
         auth = config.proxy_username + password_part
         url = '@'.join((auth, url))
 
-    url = '://'.join((protocol,url))
+    url = 'http://' + url
 
     session.proxies[protocol] = url
 


### PR DESCRIPTION
This fixes the proxy URL for the requests library (python-requests-1.1.0). You will need the protocol in the url otherwise you will receive a Invalid Argument exception.

---

~ $ python
Python 2.6.6 (r266:84292, May 27 2013, 05:35:12) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > import requests
> > > r = requests.get("http://yum.mariadb.org/5.5/rhel6-amd64/repodata/repomd.xml", proxies={'http': 'my.proxy.server:8080'})
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/usr/lib/python2.6/site-packages/requests/api.py", line 55, in get
> > >     return request('get', url, *_kwargs)
> > >   File "/usr/lib/python2.6/site-packages/requests/api.py", line 44, in request
> > >     return session.request(method=method, url=url, *_kwargs)
> > >   File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 279, in request
> > >     resp = self.send(prep, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
> > >   File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 374, in send
> > >     r = adapter.send(request, **kwargs)
> > >   File "/usr/lib/python2.6/site-packages/requests/adapters.py", line 206, in send
> > >     raise ConnectionError(sockerr)
> > > requests.exceptions.ConnectionError: [Errno 22] Invalid argument
> > > r = requests.get("http://yum.mariadb.org/5.5/rhel6-amd64/repodata/repomd.xml", proxies={'http': 'http://my.proxy.server:8080'})

Please see http://www.python-requests.org/en/latest/user/advanced/  (Proxies section)
