### PR TITLE
1126083 - no longer logging a failed download at ERROR level

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -240,7 +240,7 @@ class HTTPThreadedDownloader(Downloader):
             report.download_canceled()
 
         except DownloadFailed, e:
-            _LOG.error(str(e))
+            _LOG.debug('download failed: %s' % str(e))
             report.error_msg = e.args[2]
             report.error_report['response_code'] = e.args[1]
             report.error_report['response_msg'] = e.args[2]


### PR DESCRIPTION
Getting a 404 is sometimes perfectly normal, so there's no reason to make so much noise about it.

https://bugzilla.redhat.com/show_bug.cgi?id=1126083
