### PR TITLE
1124625 - fail quickly if there is a connection error

### DIFF
--- a/nectar/config.py
+++ b/nectar/config.py
@@ -29,7 +29,8 @@ class DownloaderConfig(object):
             ssl_client_cert_path=None, ssl_client_key=None, ssl_client_key_path=None,
             ssl_validation=True, proxy_url=None, proxy_port=None, proxy_username=None,
             proxy_password=None, max_speed=None, headers=None, buffer_size=None,
-            progress_interval=None, use_hard_links=False, use_sym_links=False):
+            progress_interval=None, use_hard_links=False, use_sym_links=False,
+            connect_timeout=6.05, read_timeout=27):
         """
         Initialize the DownloaderConfig. All parameters are optional. Not all downloaders use each
         of the configuration items, so for each parameter documented below, the downloaders that
@@ -100,6 +101,15 @@ class DownloaderConfig(object):
         :param use_sym_links:        If True, use symlinks instead of copying files. Defaults to
                                      False. (Local)
         :type  use_sym_links:        bool
+        :param connect_timeout:      Number of seconds the Requests library will wait for nectar to
+                                     establish a connection with a remote machine. From the
+                                     Requests docs: 'It’s a good practice to set connect timeouts
+                                     to slightly larger than a multiple of 3, which is the default
+                                     TCP packet retransmission window.'
+        :type connect_timeout:       float
+        :param read_timeout:         The number of seconds the client will wait for the server to
+                                     send a response after an initial connection has already been
+                                     made.
         :type  headers:              dict
         """
         self.max_concurrent = max_concurrent
@@ -123,6 +133,8 @@ class DownloaderConfig(object):
         self.use_hard_links = use_hard_links
         self.use_sym_links = use_sym_links
         self._temp_files = []
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
 
         # concurrency options
         self._process_concurrency()

--- a/nectar/report.py
+++ b/nectar/report.py
@@ -121,6 +121,22 @@ class DownloadReport(object):
             self.error_msg = _('Download Failed')
         self._download_finished(self.DOWNLOAD_FAILED)
 
+    def download_skipped(self):
+        """
+        Mark that this download has been skipped.
+        """
+        self.error_msg = _('Download skipped')
+        self.state = self.DOWNLOAD_FAILED
+
+    def download_connection_error(self):
+        """
+        Indicate that a connection error occurred
+        """
+
+        self.error_msg = _('A connection error occurred')
+        self.state = self.DOWNLOAD_FAILED
+        self.finish_time = datetime.now(tz=UTC)
+
     def download_canceled(self):
         """
         Mark the report as having been canceled.

--- a/test/unit/test_base_downloader.py
+++ b/test/unit/test_base_downloader.py
@@ -39,3 +39,15 @@ class LyingDownloader(Downloader):
         report = DownloadReport.from_download_request(request)
         self.fire_download_succeeded(report)
         return report
+
+
+class TestDownloadReport(unittest.TestCase):
+
+    def setUp(self):
+        self.report = DownloadReport("fakeurl", "fakedestination")
+
+    def test_download_connection_error(self):
+
+        self.report.download_connection_error()
+        self.assertEqual(self.report.state, self.report.DOWNLOAD_FAILED)
+        self.assertEqual(self.report.error_msg, "A connection error occurred")

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -55,6 +55,8 @@ class InstantiationTests(base.NectarTests):
         self.assertEqual(config.progress_interval, None)
         self.assertEqual(config.use_hard_links, False)
         self.assertEqual(config.use_sym_links, False)
+        self.assertEqual(config.connect_timeout, 6.05)
+        self.assertEqual(config.read_timeout, 27)
 
     def test_dict_semantic_default_value(self):
         config = DownloaderConfig(basic_auth_username='username')


### PR DESCRIPTION
Allows requests timeout settings to be configurable and set reasonable defaults. If requests does timeout (a connection error), these changes prevent requests from attempting the same base url again.
[1124625](https://bugzilla.redhat.com/show_bug.cgi?id=1124625)
