### PR TITLE
1174283 - bump python-requests requirement to match included dep

### DIFF
--- a/python-nectar.spec
+++ b/python-nectar.spec
@@ -16,7 +16,7 @@ BuildArch:      noarch
 BuildRequires:  python-setuptools
 
 Requires:       python-isodate >= 0.4.9
-Requires:       python-requests >= 2.2.1
+Requires:       python-requests >= 2.4.3
 
 %description
 Nectar is a download library that abstracts the workflow of making and tracking


### PR DESCRIPTION
https://github.com/pulp/nectar/pull/24 uses some new features in requests 2.4. Since we already this version of requests in our 2.6 builds, we should require at least that version.

https://bugzilla.redhat.com/show_bug.cgi?id=1174283
