### PR TITLE
1229-Json config file values must be url encoded.

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -421,6 +421,7 @@ def _add_proxy(session, config):
     if config.proxy_username is not None:
         password_part = config.get('proxy_password', '') and ':%s' % config.proxy_password
         auth = config.proxy_username + password_part
+        auth = urllib.quote(auth, safe=':')
         url = '@'.join((auth, url))
 
     session.proxies['https'] = '://'.join((protocol, url))

--- a/test/unit/test_threaded_downloader.py
+++ b/test/unit/test_threaded_downloader.py
@@ -53,8 +53,8 @@ class InstantiationTests(base.NectarTests):
                   'ssl_client_key_path': os.path.join(_find_data_directory(), 'pki/bogus/key.pem'),
                   'proxy_url': 'https://invalid-proxy.com',
                   'proxy_port': 1234,
-                  'proxy_username': 'anonymous',
-                  'proxy_password': 'anonymous'}
+                  'proxy_username': 'anon?ymous',
+                  'proxy_password': 'anonymous$'}
         proxy_host = urllib.splithost(urllib.splittype(kwargs['proxy_url'])[1])[0]
 
         cfg = config.DownloaderConfig(**kwargs)
@@ -72,13 +72,14 @@ class InstantiationTests(base.NectarTests):
 
         self.assertEqual(session.cert,
                          (kwargs['ssl_client_cert_path'], kwargs['ssl_client_key_path']))
+        # test proxy username and passwod are url encoded before sending the request
         self.assertEqual(session.proxies,
-                         {'http': 'https://%s:%s@%s:%d' % (kwargs['proxy_username'],
-                                                           kwargs['proxy_password'],
+                         {'http': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
+                                                           urllib.quote(kwargs['proxy_password']),
                                                            proxy_host,
                                                            kwargs['proxy_port']),
-                          'https': 'https://%s:%s@%s:%d' % (kwargs['proxy_username'],
-                                                            kwargs['proxy_password'],
+                          'https': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
+                                                            urllib.quote(kwargs['proxy_password']),
                                                             proxy_host,
                                                             kwargs['proxy_port'])})
 


### PR DESCRIPTION
closes #1229
https://pulp.plan.io/issues/1229