### PR TITLE
DownloadRequests now have a `canceled` field which cancels individual requests.

### DIFF
--- a/nectar/downloaders/local.py
+++ b/nectar/downloaders/local.py
@@ -139,7 +139,7 @@ class LocalFileDownloader(Downloader):
 
             while True:
 
-                if self.is_canceled:
+                if self.is_canceled or request.canceled:
                     report.download_canceled()
                     # NOTE the control flow here will pass through the finally
                     # block on the way out, but not the else block :D
@@ -201,7 +201,7 @@ class LocalFileDownloader(Downloader):
         report.download_started()
         self.fire_download_started(report)
 
-        if self.is_canceled:
+        if self.is_canceled or request.canceled:
             report.download_canceled()
             return report
 

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -205,7 +205,7 @@ class HTTPThreadedDownloader(Downloader):
         self.fire_download_started(report)
         netloc = urlparse.urlparse(request.url).netloc
         try:
-            if self.is_canceled:
+            if self.is_canceled or request.canceled:
                 raise DownloadCancelled(request.url)
 
             if netloc in self.failed_netlocs:
@@ -253,7 +253,7 @@ class HTTPThreadedDownloader(Downloader):
                 chunks = response.iter_content(self.buffer_size)
 
             for chunk in chunks:
-                if self.is_canceled:
+                if self.is_canceled or request.canceled:
                     raise DownloadCancelled(request.url)
 
                 file_handle.write(chunk)

--- a/nectar/request.py
+++ b/nectar/request.py
@@ -28,6 +28,7 @@ class DownloadRequest(object):
         self.destination = destination
         self.data = data
         self.headers = headers
+        self.canceled = False
 
         self._file_handle = None
 

--- a/test/unit/test_local_downloader.py
+++ b/test/unit/test_local_downloader.py
@@ -181,6 +181,20 @@ class GoodDownloadTests(DownloadTests):
         # make sure the no writing was attempted
         self.assertEqual(mock_open.return_value.write.call_count, 0)
 
+    @mock.patch('__builtin__.open')
+    @mock.patch('nectar.report.DownloadReport.download_canceled')
+    def test_copy_canceled_single_request(self, mock_canceled, mock_open):
+        downloader = local.LocalFileDownloader(DownloaderConfig())
+        request = DownloadRequest('file://' + __file__, '/bar')
+        request.canceled = True
+
+        downloader._copy(request)
+
+        # make sure the cancel method was called on the report
+        mock_canceled.assert_called_once_with()
+        # make sure the no writing was attempted
+        self.assertEqual(mock_open.return_value.write.call_count, 0)
+
     def test_copy_download(self):
         config = DownloaderConfig()
         listener = AggregatingEventListener()

--- a/test/unit/test_threaded_downloader.py
+++ b/test/unit/test_threaded_downloader.py
@@ -239,6 +239,15 @@ class TestFetch(unittest.TestCase):
                                             timeout=(self.config.connect_timeout,
                                                      self.config.read_timeout))
 
+    @mock.patch('nectar.downloaders.threaded.DownloadReport.from_download_request')
+    def test_request_cancel(self, mock_from_request):
+        url = 'http://fakeurl/robots.txt'
+        req = DownloadRequest(url, mock.Mock())
+        req.canceled = True
+
+        self.downloader._fetch(req, mock.Mock())
+        mock_from_request.return_value.download_canceled.assert_called_once_with()
+
     def test_response_headers(self):
         """
         Make sure that whatever headers come back on the response get added


### PR DESCRIPTION
This allows `download_started` to raise, for example, DownloadCancelled
in order to cancel a download if some conditions are met at start time.