### PR TITLE
Enable content sync via digest proxy

### DIFF
--- a/nectar/config.py
+++ b/nectar/config.py
@@ -207,35 +207,3 @@ class DownloaderConfig(object):
         item = getattr(self, item)
         return item if item is not None else default
 
-
-class HTTPBasicWithProxyAuth(requests.auth.AuthBase):
-    """
-    Attaches HTTP Basic Authentication and Proxy Authentication to the Request objects in a session.
-    """
-    def __init__(self, username, password, proxy_username, proxy_password):
-        """
-        :param username: username to be used to authenticate with the download server
-        :type username: basestring
-        :param password: password to be used to authenticate with the download server
-        :type password: basestring
-        :param proxy_username: username to be used to authenticate with the proxy server
-        :type proxy_username: basestring
-        :param proxy_password: password to be used to authenticate with the proxy server
-        :type proxy_password: basestring
-        """
-        self.username = username
-        self.password = password
-        self.proxy_username = proxy_username
-        self.proxy_password = proxy_password
-
-    def __call__(self, req):
-        """
-        Callable to be used by the requests library to populate the header of a download request.
-
-        :param req: download request object used by the requests library
-        :type  req: requests.models.Request
-        """
-        req.headers['Authorization'] = requests.auth._basic_auth_str(self.username, self.password)
-        req.headers['Proxy-Authorization'] = requests.auth._basic_auth_str(self.proxy_username,
-                                                                           self.proxy_password)
-        return req

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -8,8 +8,8 @@ from gettext import gettext as _
 from logging import getLogger
 
 import requests
+from requests_toolbelt.auth.guess import GuessProxyAuth
 
-from nectar.config import HTTPBasicWithProxyAuth
 from nectar.downloaders.base import Downloader
 from nectar.report import DownloadReport, DOWNLOAD_SUCCEEDED
 
@@ -424,32 +424,17 @@ def _add_proxy(session, config):
     host, remainder = urllib.splithost(remainder)
     url = ':'.join((host, str(config.proxy_port)))
 
-    if config.proxy_username is not None:
-        password_part = config.get('proxy_password', '') and ':%s' % config.proxy_password
-        auth = config.proxy_username + password_part
-        auth = urllib.quote(auth, safe=':')
-        url = '@'.join((auth, url))
-
     session.proxies['https'] = '://'.join((protocol, url))
     session.proxies['http'] = '://'.join((protocol, url))
 
     # Set session.auth if proxy username is specified
     if config.proxy_username is not None:
         proxy_password = config.get('proxy_password', '')
-        if None in (config.basic_auth_username, config.basic_auth_password):
-            # bz 1021662 - Proxy authentiation using username and password in session.proxies urls
-            # does not setup correct headers in the http download request because of a bug in
-            # urllib3. This is an alternate approach which sets up the headers correctly.
-            session.auth = requests.auth.HTTPProxyAuth(config.proxy_username, proxy_password)
-        else:
-            # The approach mentioned above works well except when a basic user authentication is
-            # used, along with the proxy authentication. Therefore, we define and use a custom class
-            # which inherits AuthBase class provided by the requests library to add the headers
-            # correctly.
-            session.auth = HTTPBasicWithProxyAuth(config.basic_auth_username,
-                                                  config.basic_auth_password,
-                                                  config.proxy_username,
-                                                  proxy_password)
+        session.auth = GuessProxyAuth(username=config.basic_auth_username,
+                                      password=config.basic_auth_password,
+                                      proxy_username=config.proxy_username,
+                                      proxy_password=proxy_password)
+
 
 # -- thread-safe generator queue -----------------------------------------------
 

--- a/python-nectar.spec
+++ b/python-nectar.spec
@@ -17,6 +17,7 @@ BuildRequires:  python-setuptools
 
 Requires:       python-isodate >= 0.4.9
 Requires:       python-requests >= 2.4.3
+Requires:       python-requests-toolbelt >= 0.6.0
 
 %description
 Nectar is a download library that abstracts the workflow of making and tracking

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,5 @@ setup(name='nectar',
                'sdist': {'dist_dir': '_dist'}},
 
       install_requires=['isodate >= 0.4.9',
-                        'requests >= 2.0.0'],)
+                        'requests >= 2.0.0',
+                        'requests-toolbelt >= 0.6.0'],)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -2,10 +2,8 @@
 
 import os
 
-import requests
-
 import base
-from nectar.config import DownloaderConfig, HTTPBasicWithProxyAuth
+from nectar.config import DownloaderConfig
 
 
 class InstantiationTests(base.NectarTests):
@@ -109,18 +107,3 @@ class InstantiationTests(base.NectarTests):
                           ssl_client_key=key_data,
                           ssl_client_key_path=key_file)
 
-    def test_http_basic_with_proxy_auth_config(self):
-        username = 'username'
-        password = 'password'
-        proxy_username = 'proxy_username'
-        proxy_password = 'proxy_password'
-        basic_plus_proxy_config = HTTPBasicWithProxyAuth(username, password,
-                                                         proxy_username, proxy_password)
-
-        request = requests.models.Request()
-        basic_plus_proxy_config(request)
-
-        expected_authorization = requests.auth._basic_auth_str(username, password)
-        expected_proxy_authorization = requests.auth._basic_auth_str(proxy_username, proxy_password)
-        self.assertEquals(request.headers['Authorization'], expected_authorization)
-        self.assertEquals(request.headers['Proxy-Authorization'], expected_proxy_authorization)

--- a/test/unit/test_threaded_downloader.py
+++ b/test/unit/test_threaded_downloader.py
@@ -74,14 +74,10 @@ class InstantiationTests(base.NectarTests):
                          (kwargs['ssl_client_cert_path'], kwargs['ssl_client_key_path']))
         # test proxy username and passwod are url encoded before sending the request
         self.assertEqual(session.proxies,
-                         {'http': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
-                                                           urllib.quote(kwargs['proxy_password']),
-                                                           proxy_host,
-                                                           kwargs['proxy_port']),
-                          'https': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
-                                                            urllib.quote(kwargs['proxy_password']),
-                                                            proxy_host,
-                                                            kwargs['proxy_port'])})
+                         {'http': 'https://%s:%d' % (proxy_host,
+                                                     kwargs['proxy_port']),
+                          'https': 'https://%s:%d' % (proxy_host,
+                                                      kwargs['proxy_port'])})
 
 
 # -- "live" tests --------------------------------------------------------------


### PR DESCRIPTION
Enable the guessing of the proxy authentication mechanism, via digest
or basic.

This will also guess the HTTP proxy, via digest or basic.

https://pulp.plan.io/issues/469
closes #469