### PR TITLE
Log the specific ConnectionError.

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -293,9 +293,7 @@ class HTTPThreadedDownloader(Downloader):
             report.download_skipped()
 
         except requests.ConnectionError as e:
-            _logger.warning("Connection Error - {url} could not be reached.".format(
-                url=request.url)
-            )
+            _logger.warning(str(e))
             self.failed_netlocs.add(netloc)
             report.download_connection_error()
 


### PR DESCRIPTION
A ConnectionError can happen for many, many reasons. It could be the
hostname could not be resolved, the connection was not accepted, etc.
This causes Nectar to log the details.