### PR TITLE
Fix checking for config.proxy_username

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -399,7 +399,7 @@ def _add_proxy(session, config):
     host, remainder = urllib.splithost(remainder)
     url = ':'.join((host, str(config.proxy_port)))
 
-    if config.proxy_username is not None:
+    if config.proxy_username:
         password_part = config.get('proxy_password', '') and ':%s' % config.proxy_password
         auth = config.proxy_username + password_part
         auth = urllib.quote(auth, safe=':')


### PR DESCRIPTION
When using basic authentication for the url to fetch and using a proxy without authentication, all the authentication gets stripped away when the proxy_username exists in the config file /etc/pulp/server/plugins.conf/yum_importer.json but is empty. This is because in threaded.py the code checks if proxy_username == None, which is untrue (it is an empty string). Since

```python
variable = ''
if variable:
  do_something
```

evaluates works as well, this is the better option in my opinion.