### PR TITLE
ConnectionError exceptions are logged at the error level

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -274,8 +274,8 @@ class HTTPThreadedDownloader(Downloader):
             report.download_skipped()
 
         except requests.ConnectionError as e:
-            _logger.warning(_('Skipping requests to {netloc} due to repeated connection'
-                              ' failures: {e}').format(netloc=netloc, e=str(e)))
+            _logger.error(_('Skipping requests to {netloc} due to repeated connection'
+                            ' failures: {e}').format(netloc=netloc, e=str(e)))
             self.failed_netlocs.add(netloc)
             report.download_connection_error()
 


### PR DESCRIPTION
Example log entry for a certificate signed with an unknown CA:
```
nectar.downloaders.threaded:ERROR: Skipping requests to cdn.redhat.com due to repeated connection failures: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
```

closes #1372