### PR TITLE
Python3 compatibility

### DIFF
--- a/nectar/config.py
+++ b/nectar/config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from builtins import object
 
 import os
 import tempfile

--- a/nectar/downloaders/base.py
+++ b/nectar/downloaders/base.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from builtins import object
+
 import logging
 
 from nectar.listener import DownloadEventListener
@@ -143,5 +145,5 @@ class Downloader(object):
         try:
             if self.fire_events:
                 event_listener_callback(*args, **kwargs)
-        except Exception, e:
+        except Exception as e:
             _LOG.exception(e)

--- a/nectar/downloaders/local.py
+++ b/nectar/downloaders/local.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 
+from future import standard_library
+from builtins import str
+from past.builtins import basestring
+
 import datetime
-import itertools
 import logging
 import os
-import urllib
+import urllib.request
+import urllib.parse
+import urllib.error
 
 from nectar.downloaders.base import Downloader
 from nectar.report import DownloadReport, DOWNLOAD_SUCCEEDED
 
+standard_library.install_aliases()
 
 logger = logging.getLogger(__name__)
 DEFAULT_BUFFER_SIZE = 1048576  # 1 MB in bytes
@@ -58,7 +64,7 @@ class LocalFileDownloader(Downloader):
 
     def download(self, request_list):
 
-        for report in itertools.imap(self.download_method, request_list):
+        for report in map(self.download_method, request_list):
 
             if report.state == DOWNLOAD_SUCCEEDED:
                 self.fire_download_succeeded(report)
@@ -157,11 +163,11 @@ class LocalFileDownloader(Downloader):
                 self.fire_download_progress(report)
                 last_progress_update = now
 
-        except IOError, e:
+        except IOError as e:
             logger.debug(e)
             report.error_msg = str(e)
             report.download_failed()
-        except Exception, e:
+        except Exception as e:
             logger.exception(e)
             report.error_msg = str(e)
             report.download_failed()
@@ -210,11 +216,11 @@ class LocalFileDownloader(Downloader):
 
             report.bytes_downloaded = os.path.getsize(request.destination)
 
-        except OSError, e:
+        except OSError as e:
             logger.debug(e)
             report.error_msg = str(e)
             report.download_failed()
-        except Exception, e:
+        except Exception as e:
             logger.exception(e)
             report.error_msg = str(e)
             report.download_failed()
@@ -234,7 +240,7 @@ class LocalFileDownloader(Downloader):
         :rtype: str
         :raises ValueError: if the URL is not for a local file
         """
-        scheme, file_path = urllib.splittype(url)
+        scheme, file_path = urllib.parse.splittype(url)
 
         if not scheme.startswith('file'):
             raise ValueError('Unsupported scheme: %s' % scheme)

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -1,9 +1,15 @@
+from future import standard_library
+from builtins import next
+from builtins import str
+from builtins import range
+from builtins import object
 import datetime
-import httplib
+import http.client
 import threading
 import time
-import urllib
-import urlparse
+import urllib.request
+import urllib.error
+import urllib.parse
 from gettext import gettext as _
 from logging import getLogger
 
@@ -13,6 +19,8 @@ from requests.packages.urllib3.util import retry
 from nectar.config import HTTPBasicWithProxyAuth
 from nectar.downloaders.base import Downloader
 from nectar.report import DownloadReport, DOWNLOAD_SUCCEEDED
+
+standard_library.install_aliases()
 
 # -- constants -----------------------------------------------------------------
 
@@ -207,7 +215,7 @@ class HTTPThreadedDownloader(Downloader):
         report = DownloadReport.from_download_request(request)
         report.download_started()
         self.fire_download_started(report)
-        netloc = urlparse.urlparse(request.url).netloc
+        netloc = urllib.parse.urlparse(request.url).netloc
         try:
             if self.is_canceled or request.canceled:
                 raise DownloadCancelled(request.url)
@@ -222,7 +230,7 @@ class HTTPThreadedDownloader(Downloader):
             report.headers = response.headers
             self.fire_download_headers(report)
 
-            if response.status_code != httplib.OK:
+            if response.status_code != http.client.OK:
                 raise DownloadFailed(request.url, response.status_code, response.reason)
 
             progress_interval = self.progress_interval
@@ -240,7 +248,10 @@ class HTTPThreadedDownloader(Downloader):
                 if self.is_canceled or request.canceled:
                     raise DownloadCancelled(request.url)
 
-                file_handle.write(chunk)
+                try:
+                    file_handle.write(chunk)
+                except TypeError:
+                    file_handle.write(unicode(chunk))  # noqa: F821
 
                 bytes_read = len(chunk)
                 report.bytes_downloaded += bytes_read
@@ -323,7 +334,7 @@ class HTTPThreadedDownloader(Downloader):
         # a header 'content-encoding: x-gzip' when it's really just a gzipped
         # file. In that case, we must ignore the declared encoding and thus prevent
         # the requests library from automatically decompressing the file.
-        parse_url = urlparse.urlparse(request.url)
+        parse_url = urllib.parse.urlparse(request.url)
 
         if parse_url.path.endswith('.gz'):
             ignore_encoding = True
@@ -395,14 +406,14 @@ def _add_proxy(session, config):
         return
 
     # Set session.proxies according to given url and port
-    protocol, remainder = urllib.splittype(config.proxy_url)
-    host, remainder = urllib.splithost(remainder)
+    protocol, remainder = urllib.parse.splittype(config.proxy_url)
+    host, remainder = urllib.parse.splithost(remainder)
     url = ':'.join((host, str(config.proxy_port)))
 
     if config.proxy_username:
         password_part = config.get('proxy_password', '') and ':%s' % config.proxy_password
         auth = config.proxy_username + password_part
-        auth = urllib.quote(auth, safe=':')
+        auth = urllib.parse.quote(auth, safe=':')
         url = '@'.join((auth, url))
 
     session.proxies['https'] = '://'.join((protocol, url))

--- a/nectar/listener.py
+++ b/nectar/listener.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from builtins import object
+
 import itertools
 
 

--- a/nectar/report.py
+++ b/nectar/report.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from builtins import object
+
 from datetime import datetime
 from gettext import gettext as _
 

--- a/nectar/request.py
+++ b/nectar/request.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from builtins import object
 
 
 class DownloadRequest(object):

--- a/test/scripts/demo.py
+++ b/test/scripts/demo.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from future import standard_library
 # run 'python -i demo.py' and see the result. You should see 'start' printed
 # and then 'finish'. Then uncomment the monkey patch line and try again. You
 # will see the 'start', but never the 'finish'.
@@ -8,11 +10,13 @@ import time
 import eventlet
 eventlet.monkey_patch()
 
+standard_library.install_aliases()
+
 
 def foo():
-    print 'start'
+    print('start')
     time.sleep(1)
-    print 'finish'
+    print('finish')
 
 
 thread = threading.Thread(target=foo)

--- a/test/unit/test_base_downloader.py
+++ b/test/unit/test_base_downloader.py
@@ -1,4 +1,5 @@
-from cStringIO import StringIO
+from future import standard_library
+from io import StringIO
 import unittest
 
 from nectar.config import DownloaderConfig
@@ -6,6 +7,8 @@ from nectar.downloaders.base import Downloader
 from nectar.listener import AggregatingEventListener
 from nectar.report import DownloadReport
 from nectar.request import DownloadRequest
+
+standard_library.install_aliases()
 
 
 class TestDownloadOne(unittest.TestCase):

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,3 +1,4 @@
+from builtins import str
 # -*- coding: utf-8 -*-
 
 import os
@@ -18,7 +19,7 @@ class InstantiationTests(base.NectarTests):
     def test_empty_instantiation(self):
         try:
             DownloaderConfig()
-        except Exception, e:
+        except Exception as e:
             self.fail(str(e))
 
     def test_default_configuration_values(self):
@@ -72,13 +73,13 @@ class InstantiationTests(base.NectarTests):
         self.assertRaises(ValueError, DownloaderConfig, max_concurrent=-1)
 
     def test_ssl_data_config_value(self):
-        ca_cert_value = 'test cert'
+        ca_cert_value = b'test cert'
         config = DownloaderConfig(ssl_ca_cert=ca_cert_value)
 
         # temporary file created
         self.assertTrue(os.path.exists(config.ssl_ca_cert_path))
         # same contents as data value
-        self.assertEqual(ca_cert_value, open(config.ssl_ca_cert_path).read())
+        self.assertEqual(ca_cert_value, open(config.ssl_ca_cert_path).read().encode('latin-1'))
 
         config.finalize()
 

--- a/test/unit/test_local_downloader.py
+++ b/test/unit/test_local_downloader.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from future import standard_library
+from builtins import str
+
 import datetime
 import os
 import shutil
 import tempfile
-from StringIO import StringIO
+from io import StringIO
 import unittest
 
 import mock
@@ -17,6 +20,7 @@ from nectar.request import DownloadRequest
 
 import base
 
+standard_library.install_aliases()
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 DATA_FILES = ['100K_file', '500K_file', '1M_file']
@@ -30,7 +34,7 @@ class InstantiationTests(base.NectarTests):
         try:
             local.LocalFileDownloader(config)
 
-        except Exception, e:
+        except Exception as e:
             self.fail(str(e))
 
     def test_progress_interval(self):
@@ -167,12 +171,12 @@ class GoodDownloadTests(DownloadTests):
         self.assertEqual(src_stat.st_size, dst_stat.st_size)
         self.assertNotEqual(src_stat.st_ino, dst_stat.st_ino)
 
-    @mock.patch('__builtin__.open')
+    @mock.patch('builtins.open')
     @mock.patch('nectar.report.DownloadReport.download_canceled')
     def test_copy_canceled(self, mock_canceled, mock_open):
         downloader = local.LocalFileDownloader(DownloaderConfig())
         downloader.cancel()
-        request = DownloadRequest('file://' + __file__, '/bar')
+        request = DownloadRequest('file://' + __file__, '/tmp/test')
 
         downloader._copy(request)
 
@@ -181,11 +185,11 @@ class GoodDownloadTests(DownloadTests):
         # make sure the no writing was attempted
         self.assertEqual(mock_open.return_value.write.call_count, 0)
 
-    @mock.patch('__builtin__.open')
+    @mock.patch('builtins.open')
     @mock.patch('nectar.report.DownloadReport.download_canceled')
     def test_copy_canceled_single_request(self, mock_canceled, mock_open):
         downloader = local.LocalFileDownloader(DownloaderConfig())
-        request = DownloadRequest('file://' + __file__, '/bar')
+        request = DownloadRequest('file://' + __file__, '/tmp/test')
         request.canceled = True
 
         downloader._copy(request)
@@ -270,7 +274,7 @@ class BadDownloadTests(DownloadTests):
         self.assertEqual(len(listener.succeeded_reports), 0)
         self.assertEqual(len(listener.failed_reports), 1)
 
-        debug_messages = ''.join([mock_call[1][0][1] for mock_call in mock_logger.debug.mock_calls])
+        debug_messages = ''.join([str(mock_call[1][0]) for mock_call in mock_logger.debug.mock_calls])  # noqa: E501
         self.assertTrue('No such file or directory' in debug_messages)
         self.assertEqual(mock_logger.exception.call_count, 0)
 
@@ -291,7 +295,7 @@ class BadDownloadTests(DownloadTests):
         self.assertEqual(len(listener.succeeded_reports), 0)
         self.assertEqual(len(listener.failed_reports), 1)
 
-        debug_messages = ''.join([mock_call[1][0][1] for mock_call in mock_logger.debug.mock_calls])
+        debug_messages = ''.join([str(mock_call[1][0]) for mock_call in mock_logger.debug.mock_calls])  # noqa: E501
         self.assertTrue('No such file or directory' in debug_messages)
         self.assertEqual(mock_logger.exception.call_count, 0)
 

--- a/test/unit/test_threaded_downloader.py
+++ b/test/unit/test_threaded_downloader.py
@@ -1,13 +1,21 @@
-from cStringIO import StringIO
+from future import standard_library
+from builtins import zip
+from builtins import range
+from io import StringIO
 import datetime
-import httplib
+import http.client
 import os
 import random
 import shutil
 import string
 import tempfile
 import unittest
-import urllib
+from six.moves import urllib
+
+try:
+    from urllib import splithost, splittype
+except ImportError:
+    from urllib.parse import splithost, splittype
 
 import mock
 from requests import Response, ConnectionError, Timeout
@@ -19,6 +27,8 @@ from nectar.config import DownloaderConfig
 from nectar.downloaders import threaded
 from nectar.report import DownloadReport
 from nectar.request import DownloadRequest
+
+standard_library.install_aliases()
 
 
 class InstantiationTests(base.NectarTests):
@@ -51,7 +61,7 @@ class InstantiationTests(base.NectarTests):
                   'proxy_port': 1234,
                   'proxy_username': 'anon?ymous',
                   'proxy_password': 'anonymous$'}
-        proxy_host = urllib.splithost(urllib.splittype(kwargs['proxy_url'])[1])[0]
+        proxy_host = splithost(splittype(kwargs['proxy_url'])[1])[0]
 
         cfg = config.DownloaderConfig(**kwargs)
         session = threaded.build_session(cfg)
@@ -70,12 +80,12 @@ class InstantiationTests(base.NectarTests):
                          (kwargs['ssl_client_cert_path'], kwargs['ssl_client_key_path']))
         # test proxy username and passwod are url encoded before sending the request
         self.assertEqual(session.proxies,
-                         {'http': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
-                                                           urllib.quote(kwargs['proxy_password']),
+                         {'http': 'https://%s:%s@%s:%d' % (urllib.parse.quote(kwargs['proxy_username']),  # noqa: E501
+                                                           urllib.parse.quote(kwargs['proxy_password']),  # noqa: E501
                                                            proxy_host,
                                                            kwargs['proxy_port']),
-                          'https': 'https://%s:%s@%s:%d' % (urllib.quote(kwargs['proxy_username']),
-                                                            urllib.quote(kwargs['proxy_password']),
+                          'https': 'https://%s:%s@%s:%d' % (urllib.parse.quote(kwargs['proxy_username']),  # noqa: E501
+                                                            urllib.parse.quote(kwargs['proxy_password']),  # noqa: E501
                                                             proxy_host,
                                                             kwargs['proxy_port'])})
 
@@ -90,7 +100,7 @@ class InstantiationTests(base.NectarTests):
                   'proxy_port': 1234,
                   'proxy_username': '',
                   'proxy_password': ''}
-        proxy_host = urllib.splithost(urllib.splittype(kwargs['proxy_url'])[1])[0]
+        proxy_host = splithost(splittype(kwargs['proxy_url'])[1])[0]
 
         cfg = config.DownloaderConfig(**kwargs)
         session = threaded.build_session(cfg)
@@ -246,8 +256,8 @@ class TestFetch(unittest.TestCase):
         URL = 'http://fakeurl/robots.txt'
         req = DownloadRequest(URL, StringIO(), headers={'pulp_header': 'awesome!'})
         response = Response()
-        response.status_code = httplib.OK
-        response.raw = StringIO('abc')
+        response.status_code = http.client.OK
+        response.raw = StringIO(u'abc')
         self.session.get = mock.MagicMock(return_value=response, spec_set=self.session.get)
 
         self.downloader._fetch(req)
@@ -275,9 +285,9 @@ class TestFetch(unittest.TestCase):
         URL = 'http://fakeurl/robots.txt'
         req = DownloadRequest(URL, StringIO(), headers={'pulp_header': 'awesome!'})
         response = Response()
-        response.status_code = httplib.OK
+        response.status_code = http.client.OK
         response.headers = {'content-length': '1024'}
-        response.raw = StringIO('abc')
+        response.raw = StringIO(u'abc')
         self.session.get.return_value = response
 
         report = self.downloader._fetch(req)
@@ -288,8 +298,8 @@ class TestFetch(unittest.TestCase):
         URL = 'http://fakeurl/primary.xml.gz'
         req = DownloadRequest(URL, StringIO())
         response = Response()
-        response.status_code = httplib.OK
-        response.raw = StringIO('abc')
+        response.status_code = http.client.OK
+        response.raw = StringIO(u'abc')
         self.session.get.return_value = response
 
         report = self.downloader._fetch(req)
@@ -304,7 +314,7 @@ class TestFetch(unittest.TestCase):
         URL = 'http://fakeurl/primary.xml'
         req = DownloadRequest(URL, StringIO())
         response = Response()
-        response.status_code = httplib.OK
+        response.status_code = http.client.OK
         response.iter_content = mock.MagicMock(return_value=['abc'], spec_set=response.iter_content)
         self.session.get = mock.MagicMock(return_value=response, spec_set=self.session.get)
 

--- a/test/utils/http_static_test_server.py
+++ b/test/utils/http_static_test_server.py
@@ -2,12 +2,16 @@
 """
 HTTP test server for writing tests against an "external" server.
 """
+from future import standard_library
+from builtins import object
 
 import atexit
 import socket
 import threading
-from BaseHTTPServer import HTTPServer
-from SimpleHTTPServer import SimpleHTTPRequestHandler
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+
+standard_library.install_aliases()
 
 
 class HTTPServerIPV6(HTTPServer):


### PR DESCRIPTION
Hello

I've created my own PR for Python 3 compatibility. I cannot be completely sure that nectar is working well with this changes because the only tool to check its functionality are included tests. With this changes included tests works well in Python 2.7.11 and 3.5.1 (in virtual environments).

**Python 2**

```
$ python --version
Python 2.7.11
$ pip freeze
coverage==4.1
flake8==2.6.2
funcsigs==1.0.2
future==0.15.2
get==0.0.11
isodate==0.5.4
mccabe==0.5.0
mock==2.0.0
nose==1.3.7
nosexcover==1.0.10
pbr==1.10.0
post==0.0.8
public==0.0.34
pycodestyle==2.0.0
pyflakes==1.2.3
query-string==0.0.8
request==0.0.8
requests==2.10.0
six==1.10.0
$ ./run-tests.sh 
..........................................::1 - - [20/Jul/2016 09:58:10] code 404, message File not found
::1 - - [20/Jul/2016 09:58:10] "GET /test/unit/data/notme HTTP/1.1" 404 -
::1 - - [20/Jul/2016 09:58:10] "GET /test/unit/data/1M_file HTTP/1.1" 200 -
::1 - - [20/Jul/2016 09:58:10] code 404, message File not found
::1 - - [20/Jul/2016 09:58:10] "GET /test/unit/data/notmeeither HTTP/1.1" 404 -
::1 - - [20/Jul/2016 09:58:10] "GET /test/unit/data/100K_file HTTP/1.1" 200 -
::1 - - [20/Jul/2016 09:58:10] "GET /test/unit/data/500K_file HTTP/1.1" 200 -
.::1 - - [20/Jul/2016 09:58:11] code 404, message File not found
::1 - - [20/Jul/2016 09:58:11] "GET /test/unit/data/idontexistanddontcreateme HTTP/1.1" 404 -
.::1 - - [20/Jul/2016 09:58:12] "GET /test/unit/data/100K_file HTTP/1.1" 200 -
.::1 - - [20/Jul/2016 09:58:13] "GET /test/unit/data/500K_file HTTP/1.1" 200 -
.........
Name                             Stmts   Miss  Cover
----------------------------------------------------
nectar.py                            0      0   100%
nectar/config.py                    76      0   100%
nectar/downloaders.py                0      0   100%
nectar/downloaders/base.py          37      3    92%
nectar/downloaders/local.py        114     10    91%
nectar/downloaders/threaded.py     249      8    97%
nectar/listener.py                  23      3    87%
nectar/report.py                    54      4    93%
nectar/request.py                   19      0   100%
----------------------------------------------------
TOTAL                              572     28    95%
----------------------------------------------------------------------
Ran 54 tests in 7.339s

OK
```

**Python 3**

```
$ python --version
Python 3.5.1
$ pip freeze
coverage==4.1
flake8==2.6.2
future==0.15.2
isodate==0.5.4
mccabe==0.5.0
mock==2.0.0
nose==1.3.7
nosexcover==1.0.10
pbr==1.10.0
pycodestyle==2.0.0
pyflakes==1.2.3
requests==2.10.0
six==1.10.0
$ ./run-tests.sh 
..........................................::1 - - [20/Jul/2016 09:57:59] "GET /test/unit/data/1M_file HTTP/1.1" 200 -
::1 - - [20/Jul/2016 09:57:59] code 404, message File not found
::1 - - [20/Jul/2016 09:57:59] "GET /test/unit/data/notmeeither HTTP/1.1" 404 -
::1 - - [20/Jul/2016 09:57:59] "GET /test/unit/data/100K_file HTTP/1.1" 200 -
::1 - - [20/Jul/2016 09:57:59] code 404, message File not found
::1 - - [20/Jul/2016 09:57:59] "GET /test/unit/data/notme HTTP/1.1" 404 -
::1 - - [20/Jul/2016 09:57:59] "GET /test/unit/data/500K_file HTTP/1.1" 200 -
.::1 - - [20/Jul/2016 09:58:00] code 404, message File not found
::1 - - [20/Jul/2016 09:58:00] "GET /test/unit/data/idontexistanddontcreateme HTTP/1.1" 404 -
.::1 - - [20/Jul/2016 09:58:01] "GET /test/unit/data/100K_file HTTP/1.1" 200 -
.::1 - - [20/Jul/2016 09:58:02] "GET /test/unit/data/500K_file HTTP/1.1" 200 -
.........
Name                             Stmts   Miss  Cover
----------------------------------------------------
nectar.py                            0      0   100%
nectar/config.py                    76      0   100%
nectar/downloaders.py                0      0   100%
nectar/downloaders/base.py          37      3    92%
nectar/downloaders/local.py        114     10    91%
nectar/downloaders/threaded.py     249     10    96%
nectar/listener.py                  23      3    87%
nectar/report.py                    54      4    93%
nectar/request.py                   19      0   100%
----------------------------------------------------
TOTAL                              572     30    95%
----------------------------------------------------------------------
Ran 54 tests in 6.335s

OK
```

Could please somebody test it with some real life examples?