### PR TITLE
Allow individual requests to provide requests kwargs

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -218,7 +218,8 @@ class HTTPThreadedDownloader(Downloader):
             _logger.debug("Attempting to connect to {url}.".format(url=request.url))
             response = self.session.get(request.url, headers=headers,
                                         timeout=(self.config.connect_timeout,
-                                                 self.config.read_timeout))
+                                                 self.config.read_timeout),
+                                        **request.requests_kw)
             report.headers = response.headers
             self.fire_download_headers(report)
 

--- a/nectar/request.py
+++ b/nectar/request.py
@@ -6,7 +6,7 @@ class DownloadRequest(object):
     Representation of a request for a file download.
     """
 
-    def __init__(self, url, destination, data=None, headers=None):
+    def __init__(self, url, destination, data=None, headers=None, requests_kw=None):
         """
         :param url:         url of the file to be downloaded
         :type  url:         str
@@ -23,6 +23,9 @@ class DownloadRequest(object):
                             will override any headers of the same key that
                             are specified in the config.
         :type  headers:     dict
+        :param requests_kw: A dictionary of keyword arguments to pass to requests when performing
+                            the ``requests.get`` call.
+        :type  requests_kw: dict
         """
 
         self.url = url
@@ -30,6 +33,7 @@ class DownloadRequest(object):
         self.data = data
         self.headers = headers
         self.canceled = False
+        self.requests_kw = requests_kw or {}
 
         self._file_handle = None
 


### PR DESCRIPTION
This is necessary since some settings, like the proxies to use for a
request, cannot be set at a session level when using Nectar like a
general download library. This is pretty hacky, but it seems like the
best approach to allow request-by-request configuration.

This is part of the fix for https://pulp.plan.io/issues/2111.