### PR TITLE
Better logging at INFO level for downloads

### DIFF
--- a/nectar/downloaders/local.py
+++ b/nectar/downloaders/local.py
@@ -158,7 +158,7 @@ class LocalFileDownloader(Downloader):
                 last_progress_update = now
 
         except IOError, e:
-            logger.debug(e)
+            logger.info(e)
             report.error_msg = str(e)
             report.download_failed()
         except Exception, e:
@@ -167,6 +167,7 @@ class LocalFileDownloader(Downloader):
             report.download_failed()
 
         else:
+            logger.info("Download succeeded: {url}.".format(url=request.url))
             report.download_succeeded()
 
         finally:
@@ -211,7 +212,7 @@ class LocalFileDownloader(Downloader):
             report.bytes_downloaded = os.path.getsize(request.destination)
 
         except OSError, e:
-            logger.debug(e)
+            logger.info(e)
             report.error_msg = str(e)
             report.download_failed()
         except Exception, e:
@@ -220,6 +221,7 @@ class LocalFileDownloader(Downloader):
             report.download_failed()
 
         else:
+            logger.info("Download succeeded: {url}.".format(url=request.url))
             report.download_succeeded()
 
         return report

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -341,11 +341,11 @@ class HTTPThreadedDownloader(Downloader):
             report.download_connection_error()
 
         except DownloadCancelled as e:
-            _logger.debug(str(e))
+            _logger.info(str(e))
             report.download_canceled()
 
         except DownloadFailed as e:
-            _logger.debug('download failed: %s' % str(e))
+            _logger.info('Download failed: %s' % str(e))
             report.error_msg = e.args[2]
             report.error_report['response_code'] = e.args[1]
             report.error_report['response_msg'] = e.args[2]
@@ -357,6 +357,9 @@ class HTTPThreadedDownloader(Downloader):
             report.download_failed()
 
         else:
+            _logger.info("Download succeeded: {url}.".format(
+                url=request.url)
+            )
             report.download_succeeded()
 
         request.finalize_file_handle()


### PR DESCRIPTION
Instead of showing success/error messages at debug level, we're now
showing them at INFO. If the error message was at a level above INFO, I
left it as is.

fixes #2315
https://pulp.plan.io/issues/2315