### PR TITLE
UnicodeEncodeError in comments provided with SSL cert/key/CA

### DIFF
--- a/nectar/config.py
+++ b/nectar/config.py
@@ -172,7 +172,10 @@ class DownloaderConfig(object):
                 data_arg_os_handle, file_arg_value = tempfile.mkstemp(dir=self.working_dir,
                                                                       prefix=prefix)
 
-                os.write(data_arg_os_handle, data_arg_value)
+                try:
+                    os.write(data_arg_os_handle, data_arg_value)
+                except UnicodeEncodeError:
+                    os.write(data_arg_os_handle, data_arg_value.encode('ascii', 'replace'))
                 os.close(data_arg_os_handle)
 
                 self._temp_files.append(file_arg_value)


### PR DESCRIPTION
A UnicodeError was being raised if non-ascii characters
were present in comments provided with SSL cert/key/CA

closes #2960