### PR TITLE
UnicodeEncodeError in comments provided with SSL cert/key/CA

### DIFF
--- a/nectar/config.py
+++ b/nectar/config.py
@@ -165,14 +165,14 @@ class DownloaderConfig(object):
                     raise AttributeError('Cannot read file: %s' % file_arg_value)
 
                 with open(file_arg_value, 'r') as file_arg_handle:
-                    setattr(self, data_arg_name, file_arg_handle.read())
+                    setattr(self, data_arg_name, file_arg_handle.read().decode('utf-8'))
 
             elif file_arg_value is None:
                 prefix = 'nectar-%s-' % data_arg_name
                 data_arg_os_handle, file_arg_value = tempfile.mkstemp(dir=self.working_dir,
                                                                       prefix=prefix)
 
-                os.write(data_arg_os_handle, data_arg_value)
+                os.write(data_arg_os_handle, data_arg_value.encode('utf-8'))
                 os.close(data_arg_os_handle)
 
                 self._temp_files.append(file_arg_value)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -72,13 +72,13 @@ class InstantiationTests(base.NectarTests):
         self.assertRaises(ValueError, DownloaderConfig, max_concurrent=-1)
 
     def test_ssl_data_config_value(self):
-        ca_cert_value = 'test cert'
+        ca_cert_value = u'\xe9test cert'
         config = DownloaderConfig(ssl_ca_cert=ca_cert_value)
 
         # temporary file created
         self.assertTrue(os.path.exists(config.ssl_ca_cert_path))
         # same contents as data value
-        self.assertEqual(ca_cert_value, open(config.ssl_ca_cert_path).read())
+        self.assertEqual(ca_cert_value, open(config.ssl_ca_cert_path).read().decode('utf-8'))
 
         config.finalize()
 
@@ -89,8 +89,8 @@ class InstantiationTests(base.NectarTests):
         cert_file = os.path.join(self.data_dir, 'pki', 'bogus', 'cert.pem')
         key_file = os.path.join(self.data_dir, 'pki', 'bogus', 'key.pem')
 
-        cert_contents = open(cert_file).read()
-        key_contents = open(key_file).read()
+        cert_contents = open(cert_file).read().decode('utf-8')
+        key_contents = open(key_file).read().decode('utf-8')
 
         config = DownloaderConfig(ssl_client_cert_path=cert_file,
                                   ssl_client_key_path=key_file)


### PR DESCRIPTION
A UnicodeError was being raised if non-ascii characters
were present in comments provided with SSL cert/key/CA

closes #2960