### PR TITLE
Always retry on 429 response, even without a retry-after header

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -90,7 +90,8 @@ class HTTPThreadedDownloader(Downloader):
 
         if not session:
             session = requests.Session()
-            retry_conf = retry.Retry(total=tries, connect=tries, read=tries, backoff_factor=1)
+            retry_conf = retry.Retry(total=tries, connect=tries, read=tries, backoff_factor=1,
+                                     status_forcelist=[429])
             retry_conf.BACKOFF_MAX = 8
             adapter = requests.adapters.HTTPAdapter(max_retries=retry_conf)
             session.mount('http://', adapter)


### PR DESCRIPTION
Requests with 429 responses ('Too many requests') are only retried by
default if the retry-after header is present.

Instead, always retry these requests. This fixes interoperability with
Quay.io, which presents 429 requests without a retry-after header.

Fixes #5173.

Signed-off-by: Tim Waugh <twaugh@redhat.com>