### PR TITLE
No shared session

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -1,4 +1,5 @@
 import datetime
+import errno
 import httplib
 import threading
 import time
@@ -6,6 +7,8 @@ import urllib
 import urlparse
 from gettext import gettext as _
 from logging import getLogger
+
+from OpenSSL.SSL import SysCallError
 
 import requests
 from requests.packages.urllib3.util import retry, url as urllib3_url
@@ -242,6 +245,42 @@ class HTTPThreadedDownloader(Downloader):
         """
         return self._fetch(request)
 
+    def _retryable_get(self, get_args, get_kwargs, retries=DEFAULT_TRIES, backoff=0.3):
+        """
+        Do requests get with configured session. Retries on connection error
+
+        :param get_args:    requests.session.get positional args
+        :type  get_args:    list
+
+        :param get_kwargs:  requests.session.get keyword arguments
+        :type  get_kwargs:  dict
+
+        :param retries:     number of retries
+        :type  retries:     int
+
+        :param backoff:     backoff factor for retries
+        :type  backoff:     float
+
+        :return:    requests response
+        :rtype:     requests.Response
+        """
+
+        tries = 0
+        while True:
+            try:
+                response = self.session.get(*get_args, **get_kwargs)
+            except SysCallError as e:
+                if e.args[0] != errno.ECONNRESET:
+                    raise(e)
+                _logger.exception(e)
+                if retries < 1:
+                    raise(e)
+                retries -= 1
+                tries += 1
+                time.sleep(backoff * pow(2, tries) - 1)
+            else:
+                return response
+
     def _fetch(self, request):
         """
         :param request: download request object with details about what to
@@ -269,10 +308,10 @@ class HTTPThreadedDownloader(Downloader):
 
             _logger.debug("Attempting to connect to {url}.".format(url=request.url))
             requests_kwargs = self.requests_kwargs_from_nectar_config(self.config)
-            response = self.session.get(request.url, headers=headers,
-                                        timeout=(self.config.connect_timeout,
-                                                 self.config.read_timeout),
-                                        **requests_kwargs)
+            get_kwargs = dict(headers=headers, timeout=(self.config.connect_timeout,
+                                                        self.config.read_timeout))
+            get_kwargs.update(requests_kwargs)
+            response = self._retryable_get((request.url,), get_kwargs)
             report.headers = response.headers
             self.fire_download_headers(report)
 


### PR DESCRIPTION
Do not share requests session within multiple threads
    
If one session object is shared within multiple threads, it can
happen it ran out of retries even for new connections which is not
desired. Constant number of retries should be applied to every
request. In this commit session object is created per every
worker thread
