### PR TITLE
Added 'extra_headers' attribute as replacement for session.headers

### DIFF
--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -57,7 +57,7 @@ class HTTPThreadedDownloader(Downloader):
     HTTP, HTTPS and proxied download requests by the server.
     """
 
-    def __init__(self, config, event_listener=None, tries=DEFAULT_TRIES):
+    def __init__(self, config, event_listener=None, tries=DEFAULT_TRIES, session=None):
         """
         :param config: downloader configuration
         :type config: nectar.config.DownloaderConfig
@@ -66,6 +66,10 @@ class HTTPThreadedDownloader(Downloader):
         :param tries: total number of requests made to the remote server,
                       including first unsuccessful one
         :type tries: int
+        :param session: The requests Session to use when downloaded. If one
+                        is not provided, one will be created and used for the
+                        lifetime of this downloader.
+        :type  session: requests.Session
         """
 
         super(HTTPThreadedDownloader, self).__init__(config, event_listener)
@@ -83,6 +87,7 @@ class HTTPThreadedDownloader(Downloader):
 
         # set of locations that produced a connection error
         self.failed_netlocs = set([])
+        self.session = session
 
     def _make_session(self):
         session = requests.Session()

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -57,7 +57,7 @@ class HTTPThreadedDownloader(Downloader):
     HTTP, HTTPS and proxied download requests by the server.
     """
 
-    def __init__(self, config, event_listener=None, tries=DEFAULT_TRIES, session=None):
+    def __init__(self, config, event_listener=None, tries=DEFAULT_TRIES):
         """
         :param config: downloader configuration
         :type config: nectar.config.DownloaderConfig
@@ -66,10 +66,6 @@ class HTTPThreadedDownloader(Downloader):
         :param tries: total number of requests made to the remote server,
                       including first unsuccessful one
         :type tries: int
-        :param session: The requests Session to use when downloaded. If one
-                        is not provided, one will be created and used for the
-                        lifetime of this downloader.
-        :type  session: requests.Session
         """
 
         super(HTTPThreadedDownloader, self).__init__(config, event_listener)

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -176,7 +176,10 @@ class HTTPThreadedDownloader(Downloader):
                 request = queue.get()
                 if request is None or self.is_canceled:
                     break
-                session = self._make_session()
+                if not self.session:
+                    session = self._make_session()
+                else:
+                    session = self.session
                 self._fetch(session, request)
         except:
             msg = _('Unhandled Exception in Worker Thread [%s]') % threading.currentThread().ident

--- a/nectar/downloaders/threaded.py
+++ b/nectar/downloaders/threaded.py
@@ -88,6 +88,7 @@ class HTTPThreadedDownloader(Downloader):
         # set of locations that produced a connection error
         self.failed_netlocs = set([])
         self.session = session
+        self.extra_headers = {}
 
     def _make_session(self):
         session = requests.Session()
@@ -254,6 +255,7 @@ class HTTPThreadedDownloader(Downloader):
         """
         headers = (self.config.headers or {}).copy()
         headers.update(request.headers or {})
+        headers.update(self.extra_headers.copy())
         ignore_encoding, additional_headers = self._rfc2616_workaround(request)
         headers.update(additional_headers or {})
         max_speed = self._calculate_max_speed()  # None or integer in bytes/second


### PR DESCRIPTION
Because session was previously shared for whole Downloader and now
it's created for every request, it's not possible to use it as
holder for required http headers. HTTPThreadedDownloader.extra_headers
should be now used as replacement for
HTTPThreadedDownloader.session.headers